### PR TITLE
hotfix/pluralization, better error messages, zero-one-or-many approach

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
       - run: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" >> ~/.npmrc
       - run: npm run build-lib
       - run: cp ./CHANGELOG.md ./dist/smarti18n/CHANGELOG.md
-      - run: cp ./CHANGELOG.md ./dist/smarti18n/LICENSE
+      - run: cp ./LICENSE ./dist/smarti18n/LICENSE
       - run: npm publish ./dist/smarti18n
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.7
+- Simple pluralization approach changed from `one-or-many` to `zero-one-or-many`.
+- More descriptive error messages for pluralization errors.
+
 ## 0.5.6
 - Documentation updated to cover the wholw library instructions.
 

--- a/projects/smarti18n/CHANGELOG.md
+++ b/projects/smarti18n/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.7
+- Simple pluralization approach changed from `one-or-many` to `zero-one-or-many`.
+- More descriptive error messages for pluralization errors.
+
 ## 0.5.6
 - Documentation updated to cover the wholw library instructions.
 

--- a/projects/smarti18n/package.json
+++ b/projects/smarti18n/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "smarti18n",
-	"version": "0.5.6",
+	"version": "0.5.7",
 	"repository": "github:rafapaulin/smarti18n",
 	"keywords": [],
 	"homepage": "https://github.com/rafapaulin/smarti18n#readme",

--- a/projects/smarti18n/src/lib/utils/string-utils.spec.ts
+++ b/projects/smarti18n/src/lib/utils/string-utils.spec.ts
@@ -21,12 +21,14 @@ describe('StringUtils', () => {
 	});
 
 	describe('pluralize()', () => {
-		const subject1 = 'There is one orange.|There are many oranges.';
-		const subject2 = '{0}There is no oranges.|{1}There is one orange.|[2,10]There are some oranges.|[11,*]There are many oranges.';
+		const subject1 = 'There are no oranges.|There is one orange.|There are many oranges.';
+		const subject2 = '{0}There are no oranges.|{1}There is one orange.|[2,10]There are some oranges.|[11,*]There are many oranges.';
 
 		it('should pluralize the provided simple sentences', () => {
+			const result = StringUtils.pluralize(subject1, 0);
 			const result1 = StringUtils.pluralize(subject1, 1);
 			const result2 = StringUtils.pluralize(subject1, 5);
+			expect(result).toBe('There are no oranges.');
 			expect(result1).toBe('There is one orange.');
 			expect(result2).toBe('There are many oranges.');
 		});
@@ -36,7 +38,7 @@ describe('StringUtils', () => {
 			const result2 = StringUtils.pluralize(subject2, 1);
 			const result3 = StringUtils.pluralize(subject2, 5);
 			const result4 = StringUtils.pluralize(subject2, 20);
-			expect(result1).toBe('There is no oranges.');
+			expect(result1).toBe('There are no oranges.');
 			expect(result2).toBe('There is one orange.');
 			expect(result3).toBe('There are some oranges.');
 			expect(result4).toBe('There are many oranges.');

--- a/projects/smarti18n/src/lib/utils/string-utils.ts
+++ b/projects/smarti18n/src/lib/utils/string-utils.ts
@@ -33,9 +33,12 @@ export class StringUtils {
 		const COMPLEX_COUNT_REGEX = /^(?:(?:{(\d+)})|(?:\[(\d+),(\d+|\*)\]))/;
 
 		if (string.indexOf('|') === -1)
-			throw new Error('There is no plural options. Please use pipe "|" to separe the plural options.');
+			throw new Error(`There is no plural options. Please use pipe "|" to separe the plural options. (string: ${string})`);
 
 		const options = string.split('|');
+
+		if (options.length < 3)
+			throw new Error(`You need to provide at least 3 plural options on your string. (string: ${string})`);
 
 		if (options.every(opt => COMPLEX_COUNT_REGEX.test(opt))) {
 			for (const i in options) {
@@ -47,7 +50,7 @@ export class StringUtils {
 								.filter(val => !!val)
 								.map(val => val === '*' ? Number.MAX_SAFE_INTEGER : Number(val));
 
-				if (range[1] && range[0] >= range[1]) throw new Error(`Lower limit must be less than higher limit. (${options[i]})`);
+				if (range[1] && range[0] >= range[1]) throw new Error(`Lower limit must be less than higher limit. (string: ${options[i]})`);
 
 				if (
 					(range.length === 1 && countVal === range[0]) ||
@@ -58,7 +61,7 @@ export class StringUtils {
 		} else if (options.some(opt => COMPLEX_COUNT_REGEX.test(opt)))
 			throw new Error('Please provide the quantity notation ({total} or [min, max]) in all pluralization options.');
 		else
-			return countVal > 1 ? options[1] : options[0];
+			return countVal === 0 ? options[0] : (countVal === 1 ? options[1] : options[2]);
 
 		return string;
 	}

--- a/src/app/test/test.component.html
+++ b/src/app/test/test.component.html
@@ -24,6 +24,8 @@
 </div>
 <div class="test-entry">
 		<h4>pluralization:</h4>
+		<h5>Simple (none):</h5>
+		<p smarti18n="TestComponent.pluralization.test1" smarti18nToCount="0"></p>
 		<h5>Simple (singular):</h5>
 		<p smarti18n="TestComponent.pluralization.test1" smarti18nToCount="1"></p>
 		<h5>Simple (plural):</h5>
@@ -38,12 +40,16 @@
 		<p smarti18n="TestComponent.pluralization.test2" smarti18nToCount="20"></p>
 
 		<h4>pluralization with variable interpolation:</h4>
+		<h5>Simple (none):</h5>
+		<p smarti18n="TestComponent.pluralization.test3" smarti18nToCount="0" [smarti18nParams]="{qtd: 0}"></p>
 		<h5>Simple (singular):</h5>
 		<p smarti18n="TestComponent.pluralization.test3" smarti18nToCount="1" [smarti18nParams]="{qtd: 1}"></p>
 		<h5>Simple (plural):</h5>
 		<p smarti18n="TestComponent.pluralization.test3" smarti18nToCount="5" [smarti18nParams]="{qtd: 5}"></p>
 
 		<h4>Pluralization - Same as above, with pipe:</h4>
+		<h5>Simple (none):</h5>
+		<p>{{ 'TestComponent.pluralization.test1' | smarti18n:null:0 }}</p>
 		<h5>Simple (singular):</h5>
 		<p>{{ 'TestComponent.pluralization.test1' | smarti18n:null:1 }}</p>
 		<h5>Simple (plural):</h5>
@@ -58,6 +64,8 @@
 		<p>{{ 'TestComponent.pluralization.test2' | smarti18n:null:20 }}</p>
 
 		<h4>pluralization with variable interpolation and pipe:</h4>
+		<h5>Simple (none):</h5>
+		<p>{{ 'TestComponent.pluralization.test3' | smarti18n:{qtd: 0}:0 }}</p>
 		<h5>Simple (singular):</h5>
 		<p>{{ 'TestComponent.pluralization.test3' | smarti18n:{qtd: 1}:1 }}</p>
 		<h5>Simple (plural):</h5>

--- a/src/assets/i18n/en-us.i18n.json
+++ b/src/assets/i18n/en-us.i18n.json
@@ -11,9 +11,9 @@
 			"test1": "I have an iguana. Its name is :iguanaName. I also have two cats: a black one named :blackCatName, and a white one called :whiteCatName."
 		},
 		"pluralization": {
-			"test1": "There is one orange.|There are many oranges.",
+			"test1": "There are no oranges.|There is one orange.|There are many oranges.",
 			"test2": "{0}There is no oranges.|{1}There is one orange.|[2,10]There are some oranges.|[11,*]There are many oranges.",
-			"test3": "There is :qtd orange.|There are :qtd oranges."
+			"test3": "There are :qtd oranges.|There is :qtd orange.|There are :qtd oranges."
 		}
 	}
 }

--- a/src/assets/i18n/pt-br.i18n.json
+++ b/src/assets/i18n/pt-br.i18n.json
@@ -13,9 +13,9 @@
 			"test1": "Eu tenho um Iguana. Seu nome é :iguanaName. Eu tenho também duas gatinhas: uma preta chamada :blackCatName, e uma branca chamada :whiteCatName."
 		},
 		"pluralization": {
-			"test1": "Existe uma laranja.|Existem várias laranjas.",
+			"test1": "Não existe nenhuma laranja.|Existe uma laranja.|Existem várias laranjas.",
 			"test2": "{0}Não existe nenhuma laranja.|{1}Existe uma laranja.|[2,10]Existe algumas laranjas.|[11,*]Existe várias laranjas.",
-			"test3": "Existe :qtd laranja.|Existe :qtd laranjas."
+			"test3": "Existe :qtd laranjas.|Existe :qtd laranja.|Existe :qtd laranjas."
 		}
 	}
 }


### PR DESCRIPTION
- More descriptive error messages were written for the pluralization
  method
- The simple pluralization approach chaged from the one-or-many
  to zero-one-or-many.
- Unit tests adjusted to fit the new approach

This commit fixes #30 